### PR TITLE
Improve Live and Archive section

### DIFF
--- a/_data/live.csv
+++ b/_data/live.csv
@@ -1,4 +1,5 @@
 date,name,venue,url
+2026-07-24,DG Live @ Schlossfest Ohrdruf,,https://www.ohrdruf.de/portal/suche.html?suchbegriff=Schlossfest
 2025-12-12,Regionalhelden Doppelpack DG & RAMRODS,Kofferfabrik Fürth,https://www.kofferfabrik.cc/termine.html?TYP=DETAIL&VERANSTALTUNGID=119397&DATUM=2025-12-12
 2025-02-22,DG & BAMM Bender & the Mighty Machinery,Kofferfabrik Fürth,https://www.kofferfabrik.cc/termine.html?TYP=DETAIL&VERANSTALTUNGID=295001&DATUM=2025-02-22
 2024-07-05,Fürth Festival,,https://www.nn.de/fuerth/nach-dem-em-dampfer-prachtige-stimmung-und-reichlich-musik-beim-furth-festival-1.14333301

--- a/_includes/live-table.html
+++ b/_includes/live-table.html
@@ -1,9 +1,22 @@
 {% assign last_year = 0 %}
 {% assign events = include.events %}
 <table class="table table-dark table-hover align-middle">
-  {% for event in events %} {% assign current_year = event.date | date:
-  "%Y" %} {% assign href = event.url | default: "#" %} {% if current_year !=
-  last_year == true %}
+  {% if include.placeholder_year %}
+    {% assign first_event_year = events.first.date | date: "%Y" %}
+    {% if first_event_year != include.placeholder_year %}
+      <tbody>
+        <tr>
+          <td colspan="3" class="p-4 text-muted text-center fst-italic border-0">Neue Termine folgen in Kürze...</td>
+        </tr>
+      </tbody>
+      {% assign last_year = include.placeholder_year %}
+    {% endif %}
+  {% endif %}
+
+  {% for event in events %} 
+  {% assign current_year = event.date | date: "%Y" %} 
+  {% assign href = event.url | default: "#" %} 
+  {% if current_year != last_year == true %}
   <thead>
     <tr>
       <th class="col-12 p-4" colspan="3"><h3>{{ current_year }}</h3></th>

--- a/_includes/live.html
+++ b/_includes/live.html
@@ -1,11 +1,11 @@
 {% assign current_year = 'now' | date: "%Y" %} {% assign live_events =
-site.data.live | where_exp:"item", "item.date >= current_year" %} {% assign
+site.data.live | where_exp:"item", "item.date >= current_year" | sort: "date" %} {% assign
 archive_events = site.data.live | where_exp:"item", "item.date < current_year"
 %}
 <section id="live">
   <div class="container mt-5 text-center">
     <h1>Live</h1>
-    <div class="row">{%- include live-table.html events = live_events -%}</div>
+    <div class="row">{%- include live-table.html events = live_events placeholder_year = current_year -%}</div>
   </div>
   <!-- LIVE END -->
   <!-- ARCHIVE -->
@@ -18,7 +18,7 @@ archive_events = site.data.live | where_exp:"item", "item.date < current_year"
       aria-expanded="false"
       aria-controls="event-archive"
     >
-      <h2>Archive</h2>
+      <h2>Archive <i class="fas fa-chevron-down ms-2"></i></h2>
     </button>
     <div class="row collapse" id="event-archive">
       {%- include live-table.html events = archive_events -%}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -165,3 +165,14 @@ img.album {
 .cc-link {
   color: $primary !important;
 }
+
+/* Archive Toggle Chevron */
+[data-bs-toggle="collapse"] {
+  .fa-chevron-down {
+    transition: transform 0.3s ease-in-out;
+  }
+  
+  &[aria-expanded="true"] .fa-chevron-down {
+    transform: rotate(180deg);
+  }
+}


### PR DESCRIPTION
This PR improves the Live and Archive sections:
- Adds a rotating chevron icon to the Archive button for better visual indication.
- Ensures the Live section always has content by adding a German placeholder ('Neue Termine folgen in Kürze...') if no shows are scheduled for the current year.
- Sorts upcoming live events in ascending order (soonest first).
- Fixes minor styling issues (border on placeholder, alignment).