### PR TITLE
feat(social-feed): replace Juicer iframe with Behold.so widget

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -57,5 +57,5 @@ Official Jekyll static website for the Nuremberg-based rock & pop band **Daily G
 - [ ] Phase 1: Analytics & Cookie Banner Cleanup (Remove GA4 and Osano consent banner)
 - [ ] Phase 2: Live Events CSV Audit & Hero Next-Gig Indicator
 - [ ] Phase 3: News Automation CLI Tool (`make new-post` / `scripts/new_post.sh`)
-- [ ] Phase 4: Native Social Feed (`_data/social.json` + `scripts/fetch_social.rb`)
+- [x] Phase 4: Behold.so Social Feed Integration (`_includes/social-feed.html` + `_config.yml`)
 <!-- BACKLOG_END -->

--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://dailygrindband.com" # the base hostname & protocol for your site, e.g. http://example.com
 permalink: posts/:year/:month/:day/:title:output_ext
 google-analytics-id: G-WP4DSSB93G
-behold-feed-id: "" # Insert Behold.so feed ID here (e.g. "xXxXxXxXxXxXxXxXxXxX")
+behold-feed-id: "XN95qguQK97MlfBRorMx"
 
 # Hero
 hero-carousel:

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://dailygrindband.com" # the base hostname & protocol for your site, e.g. http://example.com
 permalink: posts/:year/:month/:day/:title:output_ext
 google-analytics-id: G-WP4DSSB93G
+behold-feed-id: "" # Insert Behold.so feed ID here (e.g. "xXxXxXxXxXxXxXxXxXxX")
 
 # Hero
 hero-carousel:

--- a/_includes/social-feed.html
+++ b/_includes/social-feed.html
@@ -1,15 +1,11 @@
 <section id="social-feed">
   <div class="container text-center">
     <h1>Social Feed</h1>
-    <div class="row">
-      <iframe
-        title="Daily Grind Social Feed"
-        class="col"
-        src="https://www.juicer.io/api/feeds/dailygrind-rocks/iframe?truncate=6&amp;per=6&amp;overlay=true"
-        frameborder="0"
-        height="1540"
-      >
-      </iframe>
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-10">
+        <figure data-behold-id="{% if site.behold-feed-id != blank %}{{ site.behold-feed-id }}{% else %}REPLACE_WITH_BEHOLD_FEED_ID{% endif %}"></figure>
+        <script type="module" src="https://w.behold.so/widget.js"></script>
+      </div>
     </div>
   </div>
 </section>

--- a/_includes/social-feed.html
+++ b/_includes/social-feed.html
@@ -1,10 +1,23 @@
-<section id="social-feed">
+<section id="social-feed" class="py-5">
   <div class="container text-center">
-    <h1>Social Feed</h1>
+    <h1 class="mb-4">Social Feed</h1>
     <div class="row justify-content-center">
       <div class="col-12 col-lg-10">
-        <figure data-behold-id="{% if site.behold-feed-id != blank %}{{ site.behold-feed-id }}{% else %}REPLACE_WITH_BEHOLD_FEED_ID{% endif %}"></figure>
-        <script type="module" src="https://w.behold.so/widget.js"></script>
+        {% if site.behold-feed-id != blank %}
+          <div class="behold-widget-wrapper">
+            <figure data-behold-id="{{ site.behold-feed-id }}"></figure>
+            <script type="module" src="https://w.behold.so/widget.js"></script>
+          </div>
+        {% else %}
+          <div class="p-4 p-md-5 rounded-4 bg-dark border border-secondary border-opacity-25 my-3">
+            <i class="fa-brands fa-instagram fa-3x mb-3 text-danger"></i>
+            <h3 class="h4 mb-2">Folge uns auf Instagram</h3>
+            <p class="text-body-secondary mb-4">Erhalte Einblicke hinter die Kulissen, Live-Impressionen und aktuelle News direkt auf Instagram.</p>
+            <a href="https://www.instagram.com/dailygrind.rocks" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light rounded-pill px-4 py-2">
+              <i class="fa-brands fa-instagram me-2"></i>@dailygrind.rocks besuchen
+            </a>
+          </div>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -176,3 +176,11 @@ img.album {
     transform: rotate(180deg);
   }
 }
+
+/* Behold Social Feed Widget */
+.behold-widget-wrapper {
+  min-height: 320px;
+  figure[data-behold-id] {
+    margin: 0;
+  }
+}

--- a/conductor/site-improvements-plan.md
+++ b/conductor/site-improvements-plan.md
@@ -38,15 +38,15 @@ Address user experience and content management pain points on `dailygrindband.co
     *   `scripts/new_post.sh` (New file)
 *   **Status:** [ ] Pending
 
-### Phase 4: Native Social Feed (Point 3)
+### Phase 4: Behold.so Social Feed Integration (Point 3)
 *   **Action:** Remove the Juicer iframe integration.
-*   **Action:** Create a static, native UI grid in `_includes/social-feed.html` that reads from a new `_data/social.json` file.
-*   **Action:** Create a Ruby script (`scripts/fetch_social.rb`) to fetch recent posts and save them to `_data/social.json`. *Note: Depending on how strict Instagram's API is currently acting, we might need to use a free RSS-to-JSON proxy, but the script will be fully prepared to handle the sync.*
+*   **Action:** Add Behold.so widget embed in `_includes/social-feed.html` controlled via `behold-feed-id` setting in `_config.yml`.
+*   **Action:** Update privacy disclosures in `privacy.md`.
 *   **Files Affected:**
+    *   `_config.yml`
     *   `_includes/social-feed.html`
-    *   `scripts/fetch_social.rb` (New file)
-    *   `_data/social.json` (New file)
-*   **Status:** [ ] Pending
+    *   `privacy.md`
+*   **Status:** [x] Implemented (Awaiting feed ID configuration from user)
 
 ## Verification
 1.  Run `make serve` and verify no cookies are set and no banner appears.

--- a/privacy.md
+++ b/privacy.md
@@ -355,13 +355,10 @@ Informationen hierzu erhalten Sie vom Anbieter unter folgendem Link:
 <a href="https://www.dataprivacyframework.gov/participant/4452">https://www.dataprivacyframework.gov/participant/4452</a>.
 </p>
 
-<h4>JUICER</h4>
+<h4>BEHOLD</h4>
 
 <p>
-Auf unserer Internetseite ist eine Social Wall von Juicer integriert. Das System Juicer bietet die Möglichkeit, Social Media Aktivitäten gebündelt in einem Social Feed auszuspielen und diesen als Social Wall auf einer Website zu platzieren. Juicer bietet die Möglichkeit, Beiträge von Facebook, Instagram und zahlreichen weiteren Social Media Kanälen einzubinden. Die Social Wall ist für jedermann, also auch für Personen, die nicht bei Instagram, Twitter etc. angemeldet sind, abrufbar. Betreibergesellschaft saas.group Inc., 304 S. Jones Blvd #1205, Las Vegas NV 89107, USA Juicer und Drittanbieter, die mit Juicer zusammenarbeiten, arbeiten EU-DSGVO konform. Juicer hat zu keinem Zeitpunkt und wird zu keinem Zeitpunkt:
-persönliche Daten von Nutzern speichern oder sammeln, die den Juicer Feed (Social Wall) auf einer Seite ansehen.
-Juicer-Nutzerdaten, abgesehen von Cookies, die dem Nutzer einen besseren Gebrauch des Systems ermöglichen, weitergeben. Dabei erfasst Juicer ein Minimum an Daten und behandelt diese diskret.
-jede Art von Daten an Soziale Netzwerke weitergeben.
+Auf unserer Website ist ein Social-Media-Feed von Behold (Behold App LLC, USA) eingebunden. Behold ermöglicht die Anzeige von Instagram-Inhalten direkt auf unserer Website. Beim Laden des Widgets können technische Daten (z. B. IP-Adresse, Browser-Informationen) an Server von Behold übertragen werden, um die Inhalte darzustellen. Die Nutzung erfolgt auf Grundlage unseres berechtigten Interesses an einer ansprechenden Außendarstellung unseres Online-Angebots gemäß Art. 6 Abs. 1 lit. f DSGVO. Weitere Informationen finden Sie in der Datenschutzerklärung von Behold unter <a href="https://behold.so/privacy" target="_blank" rel="noopener noreferrer">https://behold.so/privacy</a>.
 </p>
 
 <h2>6. Plugins und Tools</h2>


### PR DESCRIPTION
## Context & Summary
This PR replaces the expiring Juicer.io social feed iframe with a Behold.so widget integration for the `@dailygrind.rocks` Instagram feed.

### Changes
- **`_config.yml`:** Added `behold-feed-id` configuration parameter.
- **`_includes/social-feed.html`:** Replaced Juicer iframe with Behold.so web component embed.
- **`privacy.md`:** Updated data privacy disclosures from Juicer to Behold.so.
- **Roadmap (`conductor/site-improvements-plan.md` & `PROJECT.md`):** Updated Phase 4 details.

## How to Review / Complete Setup
1. Create/connect feed at [behold.so](https://behold.so) for `@dailygrind.rocks`.
2. Set `behold-feed-id: "YOUR_FEED_ID"` in `_config.yml`.
3. Run `make serve` and verify the Instagram feed renders as expected.

## Risk of Regression
- **Low:** Minimal template and config updates. Uses a fallback placeholder when `behold-feed-id` is empty.