### PR TITLE
fix(renovate): remove invalid addReviewers config option

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,6 @@
     "renovate"
   ],
   "reviewers": [],
-  "addReviewers": false,
   "assignees": [
     "ctreffs"
   ]


### PR DESCRIPTION
Fixes #64 by removing the invalid `addReviewers` key from `renovate.json`. Empty `reviewers: []` array is already present.