### PR TITLE
fix(renovate): remove assignees and suppress notifications

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,10 @@
     "renovate"
   ],
   "reviewers": [],
-  "assignees": [
-    "ctreffs"
+  "assignees": [],
+  "suppressNotifications": [
+    "prIgnoreNotification",
+    "prEditNotification",
+    "branchAutomergeFailure"
   ]
 }


### PR DESCRIPTION
Removes assignees and adds `suppressNotifications` in `renovate.json` to stop Renovate email alerts.