### PR TITLE
feat: add news agent skill

### DIFF
--- a/.agents/skills/news-automation/SKILL.md
+++ b/.agents/skills/news-automation/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: news-automation
+description: Use when creating, drafting, or publishing news posts for Daily Grind, processing news media assets, or scaffolding new post files in _posts/.
+---
+
+# News Automation
+
+## overview
+This skill defines standard workflows and quality controls for creating, processing media for, and publishing news posts on the Daily Grind website (`dailygrindband.com`).
+
+## when to use
+- Drafting or scaffolding a new news post file in `_posts/`.
+- Importing and optimizing image or video assets for a news update.
+- Formatting post frontmatter, links, or energetic German band updates.
+
+## cannot
+- NEVER place raw, unoptimized image or video files directly into `assets/images/news/` or `assets/videos/news/` without processing via the Makefile import commands.
+- NEVER hardcode absolute production URLs for live event sections; ALWAYS use `{{ site.url }}#live` for live gig references.
+- NEVER omit required frontmatter fields (`layout: page`, `title`, `assets`).
+- NEVER write post text in passive or unenergetic tones; post text MUST represent an energetic German rock band.
+
+## workflow
+
+### 1. Process Media Assets First
+Before scaffolding the markdown file, convert and optimize all attached media using the Makefile tasks:
+
+- **For images** (JPEG, PNG, etc.):
+  ```bash
+  make import-image-asset FILE="path/to/photo.jpg"
+  ```
+  *(Outputs optimized WebP image to `assets/images/news/`)*
+
+- **For videos** (MP4, MOV, etc.):
+  ```bash
+  make import-video-asset FILE="path/to/video.mp4"
+  ```
+  *(Outputs optimized MP4 video to `assets/videos/news/`)*
+
+Note the relative web path of generated files (e.g., `/assets/images/news/photo.webp` or `/assets/videos/news/video.mp4`).
+
+### 2. Scaffold Post File
+Create a new post file in `_posts/` with the file naming convention `YYYY-MM-DD-kebab-case-title.md`.
+
+Inject the mandatory Jekyll frontmatter block:
+
+```markdown
+---
+layout: page
+title: "Your Energetic Title"
+assets:
+  - /assets/images/news/your-asset.webp
+---
+```
+
+### 3. Write Post Content
+Draft the content in German matching the energetic Daily Grind rock band voice:
+- Express enthusiasm, band updates, gig announcements, or release info.
+- Use rock-themed emojis appropriately (🎸, 🤘, 🔥, ⚡).
+- Reference upcoming concert dates using relative site links: `[date & location]({{ site.url }}#live)`.
+- End with energetic sign-offs (e.g., "Stay tuned und rock on! 🔥").
+
+### 4. Verify Build
+Verify that Jekyll parses the new post and assets compile cleanly:
+```bash
+make build
+```
+
+## operating rules
+- **Frontmatter Invariant**: `layout` MUST be `page`. `title` MUST be enclosed in quotes if it contains special characters or colons. `assets` MUST be a list of root-relative paths starting with `/assets/`.
+- **Media Optimization**: Always run `make import-image-asset` or `make import-video-asset` to maintain site performance and consistent resolution.
+- **Language & Voice**: Posts MUST be in German, adopting the persona of an energetic Nürnberg rock band.
+- **Verification**: Post creation is not complete until `make build` completes without errors.

--- a/.agents/skills/news-automation/SKILL.md
+++ b/.agents/skills/news-automation/SKILL.md
@@ -31,6 +31,7 @@ Before scaffolding the markdown file, convert and optimize all attached media us
   *(Outputs optimized WebP image to `assets/images/news/`)*
 
 - **For videos** (MP4, MOV, etc.):
+  Ensure the input video uses or is saved with the `.mp4` extension (required by Jekyll carousel rendering):
   ```bash
   make import-video-asset FILE="path/to/video.mp4"
   ```
@@ -56,17 +57,17 @@ assets:
 Draft the content in German matching the energetic Daily Grind rock band voice:
 - Express enthusiasm, band updates, gig announcements, or release info.
 - Use rock-themed emojis appropriately (🎸, 🤘, 🔥, ⚡).
-- Reference upcoming concert dates using relative site links: `[date & location]({{ site.url }}#live)`.
+- Reference upcoming concert dates using site URL variables: `[date & location]({{ site.url }}#live)`.
 - End with energetic sign-offs (e.g., "Stay tuned und rock on! 🔥").
 
-### 4. Verify Build
-Verify that Jekyll parses the new post and assets compile cleanly:
+### 4. Verify Build and Links
+Verify that Jekyll parses the new post and link checking passes:
 ```bash
-make build
+make build && make check
 ```
 
 ## operating rules
 - **Frontmatter Invariant**: `layout` MUST be `page`. `title` MUST be enclosed in quotes if it contains special characters or colons. `assets` MUST be a list of root-relative paths starting with `/assets/`.
-- **Media Optimization**: Always run `make import-image-asset` or `make import-video-asset` to maintain site performance and consistent resolution.
+- **Media Optimization**: Always run `make import-image-asset` or `make import-video-asset` to maintain site performance and consistent resolution. Ensure video asset paths end in `.mp4` for correct carousel tag rendering.
 - **Language & Voice**: Posts MUST be in German, adopting the persona of an energetic Nürnberg rock band.
-- **Verification**: Post creation is not complete until `make build` completes without errors.
+- **Verification**: Post creation is not complete until `make build` and `make check` complete without errors.

--- a/.agents/skills/news/SKILL.md
+++ b/.agents/skills/news/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: news-automation
+name: news
 description: Use when creating, drafting, or publishing news posts for Daily Grind, processing news media assets, or scaffolding new post files in _posts/.
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Key commands are provided via the `Makefile`:
 
 - **Content Creation:**
   - **Homepage (`index.md`):** Imports modular components from `_includes/` (`hero`, `hero-links`, `news`, `live`, `bio`, `music`, `videos`, `social-feed`).
-  - **Posts (`_posts/`):** Named `YYYY-MM-DD-title.md` using the `page` layout.
+  - **Posts (`_posts/`):** Named `YYYY-MM-DD-title.md` using the `page` layout. Managed via the `news` agent skill (`.agents/skills/news/SKILL.md`).
   - **Live Dates (`_data/live.csv`):** Single source of truth for concert dates and event links.
 - **Assets:** Always use the `Makefile` import commands (`import-image-asset` / `import-video-asset`) to ensure assets are properly converted and scaled.
 - **Styling:** Main entry point is `assets/css/style.scss`. Create or modify SCSS partials inside `_sass/`. Do not directly modify `_sass/bootstrap/` as it is populated via `make setup-bootstrap`.
@@ -43,3 +43,4 @@ Key commands are provided via the `Makefile`:
 - `_layouts/`: Page templates (`base.html`, `main.html`, `page.html`).
 - `scripts/`: Shell and Ruby automation scripts for media imports and content tooling.
 - `conductor/site-improvements-plan.md`: Roadmap and feature specifications.
+- `.agents/skills/news/SKILL.md`: Agent skill for news post scaffolding and media automation.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -54,8 +54,8 @@ Official Jekyll static website for the Nuremberg-based rock & pop band **Daily G
 
 <!-- BACKLOG_START -->
 ## 📋 Current State & Backlog
-- [ ] Phase 1: News Automation Agent Skill (`.agents/skills/news-automation/SKILL.md`)
-- [ ] Phase 2: Create New News Post (using `news-automation` skill)
+- [x] Phase 1: News Automation Agent Skill (`.agents/skills/news/SKILL.md`)
+- [ ] Phase 2: Create New News Post (using `news` skill)
 - [ ] Phase 3: Live Events CSV Audit & Hero Next-Gig Indicator (`_data/live.csv` + `_includes/hero.html`)
 - [ ] Phase 4: Analytics & Cookie Banner Cleanup (Remove GA4 and Osano consent banner)
 - [x] Completed: Behold.so Social Feed Integration (`_includes/social-feed.html` + `_config.yml`)

--- a/conductor/site-improvements-plan.md
+++ b/conductor/site-improvements-plan.md
@@ -6,18 +6,18 @@ Address user experience and content management pain points on `dailygrindband.co
 ## Scope & Implementation Steps
 
 ### Phase 1: News Automation Agent Skill
-*   **Action:** Create a dedicated Agent Skill at `.agents/skills/news-automation/SKILL.md`.
+*   **Action:** Create a dedicated Agent Skill at `.agents/skills/news/SKILL.md`.
 *   **Functionality:**
     *   Provides standardized guidelines for scaffolding new posts (`_posts/YYYY-MM-DD-title.md`).
     *   Injects standard frontmatter (`layout: page`, `title`, `assets` array).
     *   Documents asset processing workflows (`make import-image-asset` / `make import-video-asset`).
     *   Enforces brand voice (energetic German rock band) and relative links (`{{ site.url }}#live`).
 *   **Files Affected:**
-    *   `.agents/skills/news-automation/SKILL.md` (New file)
+    *   `.agents/skills/news/SKILL.md` (New file)
 *   **Status:** [x] Implemented
 
 ### Phase 2: Create New News Post
-*   **Action:** Publish a new news post using the `news-automation` skill created in Phase 1.
+*   **Action:** Publish a new news post using the `news` skill created in Phase 1.
 *   **Functionality:**
     *   Scaffold new post file in `_posts/`.
     *   Process and convert any accompanying media assets using `make import-image-asset` or `make import-video-asset`.
@@ -57,7 +57,7 @@ Address user experience and content management pain points on `dailygrindband.co
 *   **Status:** [x] Implemented
 
 ## Verification
-1.  Verify `.agents/skills/news-automation/SKILL.md` exists and is recognized by agent tools.
+1.  Verify `.agents/skills/news/SKILL.md` exists and is recognized by agent tools.
 2.  Verify the new news post renders correctly and media assets compile without errors.
 3.  Verify the Hero section displays the correct upcoming gig from the cleaned CSV.
 4.  Run `make serve` and verify no cookies are set and no banner appears.

--- a/conductor/site-improvements-plan.md
+++ b/conductor/site-improvements-plan.md
@@ -14,7 +14,7 @@ Address user experience and content management pain points on `dailygrindband.co
     *   Enforces brand voice (energetic German rock band) and relative links (`{{ site.url }}#live`).
 *   **Files Affected:**
     *   `.agents/skills/news-automation/SKILL.md` (New file)
-*   **Status:** [ ] Pending
+*   **Status:** [x] Implemented
 
 ### Phase 2: Create New News Post
 *   **Action:** Publish a new news post using the `news-automation` skill created in Phase 1.


### PR DESCRIPTION
## Summary
- Added  agent skill to automate news post scaffolding, frontmatter injection, media processing, and build/link verification.
- Documented skill usage in  and updated roadmap tracking in  and .